### PR TITLE
Add presentationBackground to sheets to prevent Liquid Glass translucency

### DIFF
--- a/Buses/Views/Favorites/FavoritesView.swift
+++ b/Buses/Views/Favorites/FavoritesView.swift
@@ -155,6 +155,7 @@ struct FavoritesView: View {
                 FavoriteLocationEditView(locationToEdit: $favoriteLocationPendingEdit)
                     .presentationDetents([.medium])
                     .presentationDragIndicator(.visible)
+                    .presentationBackground(.background)
             })
         }
         .alert("Favorites.New.Title", isPresented: $isNewPending, actions: {

--- a/Buses/Views/KatsuView.swift
+++ b/Buses/Views/KatsuView.swift
@@ -84,6 +84,7 @@ struct KatsuView: View {
                 MainTabView()
                     .presentationDetents([.medium, .large])
                     .presentationBackgroundInteraction(.enabled)
+                    .presentationBackground(.background)
                     .interactiveDismissDisabled()
             }
             .mapScope(mapScope)
@@ -97,6 +98,7 @@ struct KatsuView: View {
             .sheet(isPresented: $isMoreSheetPresented, content: {
                 MoreView()
                     .presentationDragIndicator(.visible)
+                    .presentationBackground(.background)
             })
         }
     }

--- a/Buses/Views/More/MoreView.swift
+++ b/Buses/Views/More/MoreView.swift
@@ -94,6 +94,7 @@ struct MoreView: View {
                         .navigationTitle("More.UnderTheHood")
                         .navigationBarTitleDisplayMode(.inline)
                 }
+                .presentationBackground(.background)
             }
         }
     }


### PR DESCRIPTION
Sets .presentationBackground(.background) on all sheet presentations
so the content behind the sheet doesn't show through with the Liquid
Glass effect.

https://claude.ai/code/session_01AZ3zf2NKNMXa9KnX8cpipS